### PR TITLE
fix: change varchar for int type in schema.sql

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE posts (
 );
 
 CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
+    id INT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL


### PR DESCRIPTION
mapped error:
"
2023-11-01 13:30:31+00:00 [Note] [Entrypoint]: /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/schema.sql
mysql | ERROR 1063 (42000) at line 9: Incorrect column specifier for column 'id'
"