### PR TITLE
fix: adds new database connection port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - main:/var/lib/mysql
       - ./db/:/docker-entrypoint-initdb.d/
     ports:
-      - 3305:3305
+      - 3306:3306
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 1s
@@ -36,7 +36,7 @@ services:
     environment:
       WRITER_MYSQL_HOST: "mysql"
       WRITER_MYSQL_PASS: "root"
-      WRITER_MYSQL_PORT: "3305"
+      WRITER_MYSQL_PORT: "3306"
       WRITER_MYSQL_USER: "root"
       NODE_ENV: "development"
       PORT: "8081"


### PR DESCRIPTION
mapped error:
"
"message":"connect ECONNREFUSED 172.22.0.2:3305","details":{"errno":-111,"code":"ECONNREFUSED","syscall":"connect","address":"172.22.0.2","port":3305,"fatal":true}}
"